### PR TITLE
Add support for supplying multiple load balancers to check for health…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ropeproject
 .DS_Store
 logging.log
 config.json

--- a/config/config-template.json
+++ b/config/config-template.json
@@ -42,7 +42,7 @@
                     "check_config": {"file": "autoscale.py"},
                     "metric_name": "scale_me",
                     "check_type": "agent.plugin",
-                    "load_balancer": "12345",
+                    "load_balancers": [12345],
                     "max_samples": 10
                 }
             }

--- a/contrib/autoscale.py
+++ b/contrib/autoscale.py
@@ -7,42 +7,46 @@ import os
 import subprocess
 from decimal import *
 
-# Format of these (scale_down_threshold, scale_up_threshold) - anything in between results in a NOOP
+# Format of these (scale_down_threshold, scale_up_threshold) - anything in
+# between results in a NOOP
 load_average = (1.0, 2.0)
 connections_port = 80
 num_conns = (1, 50)
 memory_pct = (15.0, 60.0)
 
 
-
-################# Internal variables - do not modify ####################
+# Internal variables - do not modify #
 PROC_TCP = ["/proc/net/tcp", "/proc/net/tcp6"]
 
 
 def read_tcp_connections():
     for proc_file in PROC_TCP:
-        with open(proc_file,'r') as f:
-          content = f.readlines()
-          content.pop(0)
+        with open(proc_file, 'r') as f:
+            content = f.readlines()
+            content.pop(0)
     return content
 
+
 def remove_empty_lines(arr):
-    return [x for x in arr if x !='']
+    return [x for x in arr if x != '']
+
 
 def _hex2dec(s):
-    return str(int(s,16))
+    return str(int(s, 16))
+
 
 def get_load_average():
-	return os.getloadavg()[0]
+    return os.getloadavg()[0]
+
 
 def get_num_connections(port=80):
     ret = 0
     conns = read_tcp_connections()
     for conn in conns:
-	line = remove_empty_lines(conn.split(" "))
-	local_port = str(int(line[1].split(":")[1], 16))
-	if line[3] == '01' and local_port == str(port):
-		ret +=1
+        line = remove_empty_lines(conn.split(" "))
+        local_port = str(int(line[1].split(":")[1], 16))
+        if line[3] == '01' and local_port == str(port):
+            ret += 1
 
     return ret
 
@@ -55,24 +59,28 @@ load_avg = 1
 num_connections = 1
 phys_mem = 3
 
+
 def make_decision(load_avg, num_connections, phys_mem):
     # If everything is "do nothing" - we do nothing
     if all(var == do_nothing for var in (load_avg, num_connections, phys_mem)):
         return do_nothing
     # If one metric suggests we need to scale up - we scale up
     if any(var == scale_up for var in (load_avg, num_connections, phys_mem)):
-	return scale_up
+        return scale_up
     # If all metrics say scale down, we scale down
     if all(var == scale_down for var in (load_avg, num_connections, phys_mem)):
-	return scale_down
+        return scale_down
 
     return do_nothing
 
+
 def get_phys_mem_pct():
-    meminfo = dict((i.split()[0].rstrip(':'),int(i.split()[1])) for i in open('/proc/meminfo').readlines())
-    mem_free = meminfo.get('MemFree') + meminfo.get('Buffers') + meminfo.get('Cached')
-    getcontext().prec=3
-    return Decimal(((Decimal(meminfo.get('MemTotal'))/Decimal(mem_free))-1)*100)
+    meminfo = dict((i.split()[0].rstrip(':'), int(i.split()[1]))
+                   for i in open('/proc/meminfo').readlines())
+    mem_free = meminfo.get(
+        'MemFree') + meminfo.get('Buffers') + meminfo.get('Cached')
+    getcontext().prec = 3
+    return Decimal(((Decimal(meminfo.get('MemTotal')) / Decimal(mem_free)) - 1) * 100)
 
 
 load_avg_scale = do_nothing

--- a/raxas/core_plugins/raxmon_autoscale.py
+++ b/raxas/core_plugins/raxmon_autoscale.py
@@ -36,16 +36,19 @@
 # nodes and leaving only unhealthy ones.
 #
 # This plugin relies on the monitoring data from a Rackspace Monitoring plugin, which you can
-# find in the contrib/ directory. This should be placed in /usr/lib/rackspace-monitoring-agent/plugins/ and
-# made executable on each server in the autoscale group (through cloud-init, config management tools or already in an image).
-# This file runs local health checks (currently load average, number of active connections and memory free pct), and
-# reports its wish to either scale down, up or do nothing based on its own health.
+# find in the contrib/ directory. This should be placed in
+# /usr/lib/rackspace-monitoring-agent/plugins/ and made executable on each server in the
+# autoscale group (through cloud-init, config management tools or already in an image).
+# This file runs local health checks (currently load average, number of active connections
+# and memory free pct), and reports its wish to either scale down, up or do nothing based
+# on its own health.
 # You should edit the threshold values near the top of the file to fit your particular workload.
 #
-# The code below collects the individual wishes of all servers, and makes a collective decision by applying some logic.
+# The code below collects the individual wishes of all servers, and makes a collective decision
+# by applying some logic.
 # For example:
 # (assume three active servers)
-# One server wants to scale up = scale up (if a single node wants to scale up, we disregard everyone else)
+# One server wants to scale up = scale up (if a single node wants to do so, we disregard all else)
 # Two servers wants to scale down, one "do nothing" = do nothing
 # Three servers want to scale down = scale down
 
@@ -164,8 +167,8 @@ class Raxmon_autoscale(PluginBase):
                                    " servers in scaling group (%s) exceeds the number"
                                    " of healthy nodes in load balancer %d (%s)."
                                    " NOT scaling down!" % (active_server_count,
-                                                          load_balancer,
-                                                          num_healthy_nodes))
+                                                           load_balancer,
+                                                           num_healthy_nodes))
                     winner = do_nothing
 
         return winner

--- a/raxas/core_plugins/raxmon_autoscale.py
+++ b/raxas/core_plugins/raxmon_autoscale.py
@@ -72,9 +72,6 @@ class Raxmon_autoscale(PluginBase):
 
         config = scaling_group.plugin_config.get(self.name)
 
-        self.scale_up_value = config.get('scale_up_value', 2)
-        self.scale_down_value = config.get('scale_down_value', 1)
-        self.do_nothing_value = config.get('do_nothing_value', 3)
         self.check_config = config.get('check_config', {})
         self.metric_name = config.get('metric_name', 'scale_me')
         self.check_type = config.get('check_type', 'agent.plugin')

--- a/raxas/core_plugins/raxmon_autoscale.py
+++ b/raxas/core_plugins/raxmon_autoscale.py
@@ -138,21 +138,21 @@ class Raxmon_autoscale(PluginBase):
         if num_results == 0:
             logger.error('No data available')
             return None
-        else:
-            for result in results:
-                if result not in scale_actions.keys():
-                    logger.info(
-                        "Duff data back from monitoring '%s' not a valid return" % result)
-                    continue
-                scale_actions[result] += 1
-            if scale_actions.get(scale_up) > 0:
-                logger.info(
-                    "At least one node reports the wish to scale - scaling up...")
-                return scale_up
 
-            winner = max(
-                scale_actions.iteritems(), key=operator.itemgetter(1))[0]
-            logger.info("Collective decision: %s" % winner)
+        for result in results:
+            if result not in scale_actions.keys():
+                logger.info(
+                    "Duff data back from monitoring '%s' not a valid return" % result)
+                continue
+            scale_actions[result] += 1
+        if scale_actions.get(scale_up) > 0:
+            logger.info(
+                "At least one node reports the wish to scale - scaling up...")
+            return scale_up
+
+        winner = max(
+            scale_actions.iteritems(), key=operator.itemgetter(1))[0]
+        logger.info("Collective decision: %s" % winner)
 
         if winner == scale_down and self.lbs:
             active_server_count = self.scaling_group.state['active_capacity']

--- a/tests/test_raxauto.py
+++ b/tests/test_raxauto.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# this file is part of 'RAX-AutoScaler'
+#
+# Copyright 2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from mock import MagicMock, PropertyMock, patch
+from pyrax.cloudloadbalancers import CloudLoadBalancer
+from pyrax.cloudloadbalancers import Node
+from pyrax.cloudmonitoring import CloudMonitorCheck
+from pyrax.cloudmonitoring import CloudMonitorEntity
+from pyrax import fakes
+from raxas.core_plugins.raxmon_autoscale import Raxmon_autoscale
+from raxas.scaling_group import ScalingGroup
+
+
+@patch('pyrax.cloud_monitoring', create=True)
+class Raxmon_autoscaleTest(unittest2.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(Raxmon_autoscaleTest, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.scaling_group = MagicMock(spec=ScalingGroup)
+        self.scaling_group.plugin_config = {'raxmon_autoscale': {
+            'load_balancers': [12345, 67889],
+            'check_type': 'agent.plugin'}}
+        self.scaling_group.state = {'active_capacity': 1}
+        self.scaling_group.active_servers = ['server1']
+
+    @patch('pyrax.cloud_loadbalancers')
+    def test_make_decision_equal_nodes_two_lbs(self, fake_clb,
+                                               mock_cloud_monitoring):
+        """ Tests one healthy server in LB and one active server in
+            scaling group with a decision to scale down. Result should be
+            scale down (-1)
+        """
+        entity = fakes.FakeCloudMonitorEntity(info={'agent_id': 'server1'})
+
+        entity = MagicMock(spec=CloudMonitorEntity)
+        agent_id = PropertyMock(return_value='server1')
+        type(entity).agent_id = agent_id
+
+        check = MagicMock(spec=CloudMonitorCheck)
+        check_type = PropertyMock(return_value='agent.plugin')
+        type(check).type = check_type
+        check.get_metric_data_points.return_value = [{'average': -1}]
+
+        entity.list_checks.return_value = [check]
+        mock_cloud_monitoring.list_entities.return_value = [entity]
+
+        fake_lb = MagicMock(spec=CloudLoadBalancer)
+        fake_node_a = MagicMock(spec=Node)
+        fake_node_status = PropertyMock(return_value='ONLINE')
+        fake_node_condition = PropertyMock(return_value='ENABLED')
+        type(fake_node_a).status = fake_node_status
+        type(fake_node_a).condition = fake_node_condition
+
+        lb_nodes = PropertyMock(return_value=[fake_node_a])
+        fake_clb.get.return_value = fake_lb
+        type(fake_lb).nodes = lb_nodes
+
+        raxmon_autoscale = Raxmon_autoscale(self.scaling_group)
+        self.assertEquals(raxmon_autoscale.make_decision(), -1)
+
+    @patch('pyrax.cloud_loadbalancers')
+    def test_make_decision_equal_nodes_single_lb(self, fake_clb,
+                                                 mock_cloud_monitoring):
+        """ Tests one healthy server in LB and one active server in
+            scaling group with a decision to scale down. Result should be
+            scale down (-1)
+        """
+
+        self.scaling_group.plugin_config = {'raxmon_autoscale': {
+            'load_balancers': [12345],
+            'check_type': 'agent.plugin'}}
+
+        entity = fakes.FakeCloudMonitorEntity(info={'agent_id': 'server1'})
+
+        entity = MagicMock(spec=CloudMonitorEntity)
+        agent_id = PropertyMock(return_value='server1')
+        type(entity).agent_id = agent_id
+
+        check = MagicMock(spec=CloudMonitorCheck)
+        check_type = PropertyMock(return_value='agent.plugin')
+        type(check).type = check_type
+        check.get_metric_data_points.return_value = [{'average': -1}]
+
+        entity.list_checks.return_value = [check]
+        mock_cloud_monitoring.list_entities.return_value = [entity]
+
+        fake_lb = MagicMock(spec=CloudLoadBalancer)
+        fake_node_a = MagicMock(spec=Node)
+        fake_node_status = PropertyMock(return_value='ONLINE')
+        fake_node_condition = PropertyMock(return_value='ENABLED')
+        type(fake_node_a).status = fake_node_status
+        type(fake_node_a).condition = fake_node_condition
+
+        lb_nodes = PropertyMock(return_value=[fake_node_a])
+        fake_clb.get.return_value = fake_lb
+        type(fake_lb).nodes = lb_nodes
+
+        raxmon_autoscale = Raxmon_autoscale(self.scaling_group)
+        self.assertEquals(raxmon_autoscale.make_decision(), -1)
+
+    @patch('pyrax.cloud_loadbalancers')
+    def test_make_decision_no_nodes_single_lb(self, fake_clb,
+                                              mock_cloud_monitoring):
+        """ Tests one server active in group who wishes to scale down
+            but no healthy nodes in the load balancer.
+            Desire to scale down should be denied and 0 should be returned
+        """
+        self.scaling_group.active_servers = ['server1']
+        entity = fakes.FakeCloudMonitorEntity(info={'agent_id': 'server1'})
+
+        entity = MagicMock(spec=CloudMonitorEntity)
+        agent_id = PropertyMock(return_value='server1')
+        type(entity).agent_id = agent_id
+
+        check = MagicMock(spec=CloudMonitorCheck)
+        check_type = PropertyMock(return_value='agent.plugin')
+        type(check).type = check_type
+        check.get_metric_data_points.return_value = [{'average': -1}]
+
+        entity.list_checks.return_value = [check]
+        mock_cloud_monitoring.list_entities.return_value = [entity]
+
+        fake_lb = MagicMock(spec=CloudLoadBalancer)
+        fake_clb.get.return_value = fake_lb
+
+        raxmon_autoscale = Raxmon_autoscale(self.scaling_group)
+        self.assertEquals(raxmon_autoscale.make_decision(), 0)


### PR DESCRIPTION
…y node count before scaling down

This is useful for users who has more than one load balancer per scaling group (which is supported), to load balance multiple applications. 