### PR TITLE
Allow for non-autoscale nodes in the load balancer + bump version in devel

### DIFF
--- a/config/config-template.json
+++ b/config/config-template.json
@@ -43,6 +43,7 @@
                     "metric_name": "scale_me",
                     "check_type": "agent.plugin",
                     "load_balancers": [12345],
+                    "num_static_servers": 0,
                     "max_samples": 10
                 }
             }

--- a/raxas/core_plugins/raxmon_autoscale.py
+++ b/raxas/core_plugins/raxmon_autoscale.py
@@ -167,8 +167,9 @@ class Raxmon_autoscale(PluginBase):
                 num_healthy_nodes = self.get_lb_status(load_balancer, clb)
                 if num_healthy_nodes < (
                         active_server_count + self.num_static_servers):
-                    logger.warning("Consensus was to scale down - but number of"
-                                   " servers in scaling group (%s) exceeds the number"
+                    logger.warning("Consensus was to scale down - but number"
+                                   " of servers in scaling group (%s) plus any"
+                                   " static nodes exceeds the number"
                                    " of healthy nodes in load balancer %d (%s)."
                                    " NOT scaling down!" % (active_server_count,
                                                            load_balancer,

--- a/raxas/version.py
+++ b/raxas/version.py
@@ -18,8 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.2.29"
+VERSION = "0.4.0"
 
 
 def return_version():
-    return "rax-autoscaler v%s -- Copyright @ 2014 Rackspace" % VERSION
+    return "rax-autoscaler v%s -- Copyright @ 2014-2016 Rackspace" % VERSION

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,6 @@ netifaces>=0.10.4
 stevedore>=1.1.0
 enum34
 unittest2
+nose
+coverage
+newrelic-api

--- a/tests/test_raxauto.py
+++ b/tests/test_raxauto.py
@@ -40,9 +40,97 @@ class Raxmon_autoscaleTest(unittest2.TestCase):
         self.scaling_group = MagicMock(spec=ScalingGroup)
         self.scaling_group.plugin_config = {'raxmon_autoscale': {
             'load_balancers': [12345, 67889],
+            'num_static_servers': 0,
             'check_type': 'agent.plugin'}}
         self.scaling_group.state = {'active_capacity': 1}
         self.scaling_group.active_servers = ['server1']
+
+    @patch('pyrax.cloud_loadbalancers')
+    def test_static_lb_nodes_do_nothing(self, fake_clb, mock_cloud_monitoring):
+        """ Tests the functionality that allows static servers to be in the
+            same LB as the autoscaled nodes.
+            Active nodes in LB is one, and only one node in AS group, but also
+            a static server - should refuse to scale down even though result
+            is -1.
+        """
+        self.scaling_group.plugin_config = {'raxmon_autoscale': {
+            'load_balancers': [12345],
+            'check_type': 'agent.plugin',
+            'num_static_servers': 1}}
+
+        entity = fakes.FakeCloudMonitorEntity(info={'agent_id': 'server1'})
+
+        entity = MagicMock(spec=CloudMonitorEntity)
+        agent_id = PropertyMock(return_value='server1')
+        type(entity).agent_id = agent_id
+
+        check = MagicMock(spec=CloudMonitorCheck)
+        check_type = PropertyMock(return_value='agent.plugin')
+        type(check).type = check_type
+        check.get_metric_data_points.return_value = [{'average': -1}]
+
+        entity.list_checks.return_value = [check]
+        mock_cloud_monitoring.list_entities.return_value = [entity]
+
+        fake_lb = MagicMock(spec=CloudLoadBalancer)
+        fake_node = MagicMock(spec=Node)
+        fake_node_status = PropertyMock(return_value='ONLINE')
+        fake_node_condition = PropertyMock(return_value='ENABLED')
+        type(fake_node).status = fake_node_status
+        type(fake_node).condition = fake_node_condition
+
+        lb_nodes = PropertyMock(return_value=[fake_node])
+        fake_clb.get.return_value = fake_lb
+        type(fake_lb).nodes = lb_nodes
+
+        raxmon_autoscale = Raxmon_autoscale(self.scaling_group)
+        self.assertEquals(raxmon_autoscale.make_decision(), 0)
+        self.scaling_group.plugin_config['num_static_servers'] = 0
+
+    @patch('pyrax.cloud_loadbalancers')
+    def test_static_lb_nodes_scale_down(self, fake_clb, mock_cloud_monitoring):
+        """ Tests the functionality that allows static servers to be in the
+            same LB as the autoscaled nodes.
+            Active nodes in LB is three, but only one node in AS group -
+            should still scale down.
+            (In a live situation in this scenario
+             raxas.scaling_group.execute_policy will overrule this ruling)
+        """
+        self.scaling_group.plugin_config = {'raxmon_autoscale': {
+            'load_balancers': [12345],
+            'check_type': 'agent.plugin',
+            'num_static_servers': 1}}
+
+        entity = fakes.FakeCloudMonitorEntity(info={'agent_id': 'server1'})
+
+        entity = MagicMock(spec=CloudMonitorEntity)
+        agent_id = PropertyMock(return_value='server1')
+        type(entity).agent_id = agent_id
+
+        check = MagicMock(spec=CloudMonitorCheck)
+        check_type = PropertyMock(return_value='agent.plugin')
+        type(check).type = check_type
+        check.get_metric_data_points.return_value = [{'average': -1}]
+
+        entity.list_checks.return_value = [check]
+        mock_cloud_monitoring.list_entities.return_value = [entity]
+
+        fake_nodes = []
+        fake_lb = MagicMock(spec=CloudLoadBalancer)
+        for i in range(3):
+            fake_nodes.append(MagicMock(spec=Node))
+            fake_node_status = PropertyMock(return_value='ONLINE')
+            fake_node_condition = PropertyMock(return_value='ENABLED')
+            type(fake_nodes[i]).status = fake_node_status
+            type(fake_nodes[i]).condition = fake_node_condition
+
+        lb_nodes = PropertyMock(return_value=fake_nodes)
+        fake_clb.get.return_value = fake_lb
+        type(fake_lb).nodes = lb_nodes
+
+        raxmon_autoscale = Raxmon_autoscale(self.scaling_group)
+        self.assertEquals(raxmon_autoscale.make_decision(), -1)
+        self.scaling_group.plugin_config['num_static_servers'] = 0
 
     @patch('pyrax.cloud_loadbalancers')
     def test_make_decision_equal_nodes_two_lbs(self, fake_clb,


### PR DESCRIPTION
Master branch is at 0.3.0 whereas the version in devel was at 0.2.29.
With the introduction of a new plugin, I'd propose we move to 0.4.0 and look to merge devel into master for a new release.