### PR TITLE
Add importlib to requirements.txt and remove from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,3 @@ unittest2
 nose
 coverage
 newrelic-api
-importlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ six==1.10.0               # via debtcollector, keystoneauth1, mock, oslo.config,
 stevedore==1.10.0
 termcolor==1.1.0
 wrapt==1.10.6             # via debtcollector
+importlib==1.0.3


### PR DESCRIPTION
Autoscale will not run on centos 6 without importlib